### PR TITLE
Add vcf2maf support for `--af_gnomadg` CLI option in Ensembl VEP 107

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,57 @@
+# This workflow builds and pushes the docker image using docker's v2 action
+# which requires explicitly setting up buildx and logging in
+
+name: Build and publish container to Docker Hub
+
+on:
+  push:
+    tags: ['v[0-9]*', '[0-9]+.[0-9]+*']  # Match tags that resemble a version
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_REPO: ${{ secrets.DOCKER_REPO }}  # Example: sagebionetworks/vcf2maf
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Compute short commit SHA ID
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      -
+        name: Build and push (tagged release)
+        uses: docker/build-push-action@v3
+        if: ${{ github.event_name == 'push' }}
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKER_REPO }}:latest
+            ${{ env.DOCKER_REPO }}:${{ github.ref_name }}
+            ${{ env.DOCKER_REPO }}:commit-${{ steps.vars.outputs.sha_short }}
+      -
+        name: Build and push (manual release)
+        uses: docker/build-push-action@v3
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKER_REPO }}:commit-${{ steps.vars.outputs.sha_short }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,21 +13,21 @@ ENV PATH=/root/miniconda3/bin:$PATH
 
 # Create conda environment 
 COPY environment.yml /
-RUN conda env create -f /environment.yml && conda clean -a
-ENV PATH=/root/miniconda3/envs/vcf2maf/bin:$PATH
+RUN conda env update --name base --file /environment.yml --prune && conda clean -a
+ENV PATH=/root/miniconda3/bin:$PATH
 
 # rsync
-RUN yum install -y rsync \
+RUN yum install -y wget \
     tar \
-    perl \
-    which
+    gzip \
+    perl
 
 # Install vcf2maf
-RUN bash -c 'export VCF2MAF_URL=`curl -sL https://api.github.com/repos/nf-osi/vcf2maf/releases | grep -m1 tarball_url | cut -d\" -f4`; curl -L -o nf-osi-vcf2maf.tar.gz $VCF2MAF_URL; tar -zxf nf-osi-vcf2maf.tar.gz; cd nf-osi-vcf2maf-*'
+RUN wget -q https://github.com/Sage-Bionetworks-Workflows/vcf2maf/archive/refs/heads/gnomad-genomes.tar.gz \
+  && tar -zxf gnomad-genomes.tar.gz \
+  && chmod a+x /vcf2maf-gnomad-genomes/*.pl
+ENV PATH=/vcf2maf-gnomad-genomes:$PATH
 
-# Dump the details of the installed packages to a file for posterity
-RUN conda env export --name vcf2maf > vcf2maf.yml
+# # Dump the details of the installed packages to a file for posterity
+RUN conda env export -n base > vcf2maf.yml
 RUN conda init bash
-
-RUN mkdir /workdir
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,21 +13,25 @@ ENV PATH=/root/miniconda3/bin:$PATH
 
 # Create conda environment 
 COPY environment.yml /
-RUN conda env update --name base --file /environment.yml --prune && conda clean -a
-ENV PATH=/root/miniconda3/bin:$PATH
+RUN conda env create -f /environment.yml && conda clean -a
+ENV PATH=/root/miniconda3/envs/vep/bin:$PATH
 
 # rsync
-RUN yum install -y wget \
+RUN yum install -y rsync \
     tar \
-    gzip \
-    perl
+    perl \
+    which
 
 # Install vcf2maf
-RUN wget -q https://github.com/Sage-Bionetworks-Workflows/vcf2maf/archive/refs/heads/gnomad-genomes.tar.gz \
-  && tar -zxf gnomad-genomes.tar.gz \
-  && chmod a+x /vcf2maf-gnomad-genomes/*.pl
-ENV PATH=/vcf2maf-gnomad-genomes:$PATH
+RUN curl -s -L -o vcf2maf.tar.gz https://github.com/Sage-Bionetworks-Workflows/vcf2maf/archive/refs/heads/gnomad-genomes.tar.gz \
+  && tar -zxf vcf2maf.tar.gz \
+  && rm vcf2maf.tar.gz \
+  && mv $(find . -maxdepth 1 -type d -name '*vcf2maf*') vcf2maf \
+  && chmod a+x vcf2maf/*.pl \
+  && ln -sr vcf2maf/*.pl /usr/local/bin/
 
-# # Dump the details of the installed packages to a file for posterity
-RUN conda env export -n base > vcf2maf.yml
+# Dump the details of the installed packages to a file for posterity
+RUN conda env export --name vep > vep.yml
 RUN conda init bash
+
+RUN mkdir /workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN yum install -y rsync \
     which
 
 # Install vcf2maf
-RUN curl -s -L -o vcf2maf.tar.gz https://github.com/Sage-Bionetworks-Workflows/vcf2maf/archive/refs/heads/gnomad-genomes.tar.gz \
+RUN curl -s -L -o vcf2maf.tar.gz https://github.com/Sage-Bionetworks-Workflows/vcf2maf/archive/refs/tags/107.1.tar.gz \
   && tar -zxf vcf2maf.tar.gz \
   && rm vcf2maf.tar.gz \
   && mv $(find . -maxdepth 1 -type d -name '*vcf2maf*') vcf2maf \

--- a/README.md
+++ b/README.md
@@ -46,3 +46,47 @@ done
 
 
 ```
+
+## Adding support for `--af_gnomadg`
+
+### Original command
+
+```console
+docker run \
+	-v $HOME/data:/work/:rw -v /dev/shm/:/ref/:ro \
+	nfosi/vcf2maf:latest \
+	perl nf-osi-vcf2maf-1b34293/vcf2maf.pl --input-vcf /work/test-small.vcf \
+	--output-maf /work/test-small.maf --vep-data /ref/vep \
+	--ref-fasta /ref/fasta/Homo_sapiens_assembly38.fasta \
+	--vep-path /root/miniconda3/envs/vcf2maf/bin --ncbi-build GRCh38
+```
+
+### Using vcf2maf.sh
+
+This shell script adds support for `--af_gnomadg`
+
+```console
+docker run \
+	-v $HOME/data:/work/:rw -v /dev/shm/:/ref/:ro \
+	-v $HOME/vcf2maf-wf/:/src/:ro \
+	nfosi/vcf2maf:latest \
+	bash /src/vcf2maf.sh --input-vcf /work/test-small.vcf \
+	--output-maf /work/test-small.maf --vep-data /ref/vep \
+	--ref-fasta /ref/fasta/Homo_sapiens_assembly38.fasta \
+	--vep-path /root/miniconda3/envs/vcf2maf/bin --ncbi-build GRCh38
+```
+
+### Using vcf2maf-gnomad-genomes
+
+This uses a forked version of vcf2maf
+
+```console
+docker run \
+	-v $HOME/data:/work/:rw -v /dev/shm/:/ref/:ro \
+	sagebionetworks/vcf2maf:gnomad-genomes \
+	vcf2maf.pl --input-vcf /work/test-small.vcf \
+	--output-maf /work/test-small.maf --vep-data /ref/vep \
+	--ref-fasta /ref/fasta/Homo_sapiens_assembly38.fasta \
+	--vep-path /root/miniconda3/envs/vep/bin --ncbi-build GRCh38
+```
+

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 # You can use this file to create a conda environment for this pipeline:
 # conda env create -f environment.yml
-name: vcf2maf
+name: vep
 channels:
   - conda-forge
   - bioconda


### PR DESCRIPTION
This PR is mainly for using the modified version of vcf2maf introduced by Sage-Bionetworks-Workflows/vcf2maf/pull/1. 

I also take the opportunity to update the names of folders to improve clarity as well as make the `vcf2maf.pl` script executable and add it to the `PATH`. 

I'll need to tweak this once I make a release on Sage-Bionetworks-Workflows/vcf2maf. I'll also try to create some symlinks so that the `--vep-path` doesn't need to be specified. 

Depends on Sage-Bionetworks-Workflows/vcf2maf/pull/1